### PR TITLE
Add Dockerfile and .dockerignore for containerization support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,38 @@
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+*.egg-info/
+dist/
+build/
+.venv/
+venv/
+ENV/
+env/
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+*~
+
+# Git
+.git/
+.gitignore
+
+# Documentation
+*.md
+!README.md
+
+# Data files
+src/b3/assets/*.zip
+src/b3/assets/*.TXT
+src/b3/assets/*.csv
+
+# Other
+.DS_Store
+*.log
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y \
+    gcc \
+    g++ \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy requirements and install Python dependencies
+COPY requirements.txt .
+RUN pip install --no-cache-dir --upgrade pip && \
+    pip install --no-cache-dir -r requirements.txt
+
+# Copy application code
+COPY src/ ./src/
+
+# Expose the API port
+EXPOSE 5002
+
+# Set environment variables
+ENV PYTHONUNBUFFERED=1
+ENV PYTHONPATH=/app
+
+# Run the application
+CMD ["python", "src/web_api.py"]
+


### PR DESCRIPTION
- Introduced a Dockerfile to set up a Python 3.12-slim environment, install dependencies, and run the application.
- Created a .dockerignore file to exclude unnecessary files and directories from the Docker build context, improving build efficiency and cleanliness.